### PR TITLE
fix: 메모리 오버플로우 위험 해소

### DIFF
--- a/unix-based/icmp-ping.cpp
+++ b/unix-based/icmp-ping.cpp
@@ -81,14 +81,14 @@ int main() {
 
         // 5. data (padding)
         char data[] = "abcdefghijklmnopqrstuvwabcdefghi"; // Windows-based data (32 bytes)
-        memcpy(&icmpPacket[8], &data, sizeof(data));
+        memcpy(&icmpPacket[8], &data, sizeof(data) - 1);
 
         // 6. checksum
         uint16_t checksum = computeChecksum(icmpPacket);
         memcpy(&icmpPacket[2], &checksum, sizeof(char) * 2);
 
         // Send the packet
-        int bytesSent = sendto(sock, icmpPacket, sizeof(icmpPacket), 0,
+        long bytesSent = sendto(sock, icmpPacket, sizeof(icmpPacket), 0,
                 (struct sockaddr*) &targetAddr, sizeof(targetAddr));
 
         start_time = std::chrono::system_clock::now();
@@ -106,7 +106,7 @@ int main() {
         sockaddr_in senderAddr;
 
         unsigned int senderAddrLen = sizeof(senderAddr);
-        int bytesReceived = recvfrom(sock, recvBuffer, sizeof(recvBuffer), 0,
+        long bytesReceived = recvfrom(sock, recvBuffer, sizeof(recvBuffer), 0,
                 (struct sockaddr*) &senderAddr, &senderAddrLen);
 
         if (bytesReceived == -1) {

--- a/windows/main.cpp
+++ b/windows/main.cpp
@@ -94,14 +94,14 @@ int main() {
 
         // 5. data (padding)
         char data[] = "abcdefghijklmnopqrstuvwabcdefghi";
-        memcpy(&icmpPacket[8], &data, sizeof(data));
+        memcpy(&icmpPacket[8], &data, sizeof(data) - 1);
 
         // 6. checksum
         uint16_t checksum = computeChecksum(icmpPacket);
         memcpy(&icmpPacket[2], &checksum, sizeof(char) * 2);
 
         // Send the packet
-        int bytesSent = sendto(sock, icmpPacket, sizeof(icmpPacket), 0,
+        long bytesSent = sendto(sock, icmpPacket, sizeof(icmpPacket), 0,
                 (struct sockaddr*) &targetAddr, sizeof(targetAddr));
 
         start_time = std::chrono::system_clock::now();
@@ -120,7 +120,7 @@ int main() {
         sockaddr_in senderAddr;
 
         int senderAddrLen = sizeof(senderAddr);
-        int bytesReceived = recvfrom(sock, recvBuffer, sizeof(recvBuffer), 0,
+        long bytesReceived = recvfrom(sock, recvBuffer, sizeof(recvBuffer), 0,
                 (struct sockaddr*) &senderAddr, &senderAddrLen);
 
         if (bytesReceived == SOCKET_ERROR) {


### PR DESCRIPTION
- data 영역 memcpy 시 문자열 공백을 제거
- 패킷 송수신 결과를 담는 변수의 타입을 int에서 long으로 변경